### PR TITLE
Activating 'development' profile by default

### DIFF
--- a/maven-artifact-notifier-core/pom.xml
+++ b/maven-artifact-notifier-core/pom.xml
@@ -79,10 +79,7 @@
 		<profile>
 			<id>development</id>
 			<activation>
-				<property>
-					<!-- propriété présente en environnement m2eclipse -->
-					<name>m2e.version</name>
-				</property>
+				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
 				<profile.filter.file>src/main/filters/development.properties</profile.filter.file>


### PR DESCRIPTION
Rather than activate the development profile by the presence of the
proprietary "m2e.version" property, which may not be present in all
build environments, we activate it by default if no other profile
is specified.

Fixes #44 