### PR TITLE
Set Eclipse workspace_loc to reflect the default project directory name

### DIFF
--- a/eclipse/processor all.launch
+++ b/eclipse/processor all.launch
@@ -18,5 +18,5 @@
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m"/>
-<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:maven-artifact-notifier}"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:artifact-listener}"/>
 </launchConfiguration>


### PR DESCRIPTION
The project root directory is named `artifact-listener`, so this changes the `workspace_loc` to reflect that.
