### PR TITLE
Added scripts for running PostgreSQL and Tomcat with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,41 @@ How to start
 
 Using Eclipse and m2eclipse, just clone the repository in Eclipse.
 
+### Start Postgres
+
+#### Native PostgreSQL
+
 You need to create a PostgreSQL database called maven_artifact_notifier:
 ```
 createuser -U postgres maven_artifact_notifier
 createdb -U postgres -O maven_artifact_notifier maven_artifact_notifier
 ```
 
+#### Docker
+
+To run PostgreSQL in a [docker](https://www.docker.com/) container, run the included `docker/postgres-start.sh`.
+Shut it down with `postgres-stop.sh`. These commands assume you have Docker installed on your
+development machine and that `docker` is on your path.
+
+### Initialize Artifact Listener Database
+
 - Check that you can connect to your database using the information in development.properties Maven profile file.
 - Run eclipse/processor all.launch
 - Ensure that target/generated-sources/apt is a source folder in your eclipse project; if not please add it manually
 (source detection depends on your m2e eclipse installed plugins and options)
-- create /data/services/maven-artifact-notifier/ folder with application write access; this folder is used for lucene's
+- Create /data/services/maven-artifact-notifier/ folder with application write access; this folder is used for lucene's
 index storage (can be configured via *data.path* in *configuration.properties*)
 - Run MavenArtifactNotifierInitFromExcelMain from the init module and you should be all set.
-- Then deploy the webapp in your container of choice - we use Tomcat 7 embedded in WST.
+
+### Run Artifact Listener
+
+#### Native Tomcat
+
+Deploy the webapp (`maven-artifact-notifier-webapp/target/maven-artifact-notifier.war`) in your container of choice - we use Tomcat 7 embedded in WST.
+
+#### Docker
+
+To configure the application for local testing with Docker, build the project with the 'docker' Maven profile (`mvn clean package -Pdocker`).
+You can run it with Tomcat in a Docker container using `docker/tomcat-start.sh`, which mounts the WAR file into Tomcat's  webapps directory so you can run development builds in place. Stop it with `docker/tomcat-stop.sh`.
+
+Artifact listener should now be avalable at [http://localhost:8080/maven-artifact-notifier](http://localhost:8080/maven-artifact-notifier).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ createdb -U postgres -O maven_artifact_notifier maven_artifact_notifier
 
 To run PostgreSQL in a [docker](https://www.docker.com/) container, run the included `docker/postgres-start.sh`.
 Shut it down with `postgres-stop.sh`. These commands assume you have Docker installed on your
-development machine and that `docker` is on your path.
+development machine and that `docker` is on your path. The docker container exposes the default Postgres port of 5432,
+so that port must not be in use unless you modify the startup script to expose a different port.
 
 ### Initialize Artifact Listener Database
 
@@ -69,6 +70,6 @@ Deploy the webapp (`maven-artifact-notifier-webapp/target/maven-artifact-notifie
 #### Docker
 
 To configure the application for local testing with Docker, build the project with the 'docker' Maven profile (`mvn clean package -Pdocker`).
-You can run it with Tomcat in a Docker container using `docker/tomcat-start.sh`, which mounts the WAR file into Tomcat's  webapps directory so you can run development builds in place. Stop it with `docker/tomcat-stop.sh`.
+You can run it with Tomcat in a Docker container using `docker/tomcat-start.sh`, which mounts the WAR file into Tomcat's  webapps directory so you can run development builds in place. Stop it with `docker/tomcat-stop.sh`. The docker container exposes Tomcat's default port of 8080, so that port must not be in use unless you modify the startup script to expose a different port.
 
 Artifact listener should now be avalable at [http://localhost:8080/maven-artifact-notifier](http://localhost:8080/maven-artifact-notifier).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
 FROM postgres:9.5
 
-# Note that postgresql.sql is usually copied by postgres-start.sh to this directory
 COPY init_db.sh /docker-entrypoint-initdb.d
 COPY postgresql.sql /tmp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgres:9.5
+
+# Note that postgresql.sql is usually copied by postgres-start.sh to this directory
+COPY init_db.sh /docker-entrypoint-initdb.d
+COPY postgresql.sql /tmp

--- a/docker/init_db.sh
+++ b/docker/init_db.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Run initialization SQL
+psql -U postgres --file /tmp/postgresql.sql

--- a/docker/postgres-start.sh
+++ b/docker/postgres-start.sh
@@ -9,8 +9,6 @@ if [ -n "$cid" ]; then
 else
     # Build a docker image
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    # Copy the SQL init script into $DIR since Docker won't pull it in from outside this directory
-    cp $DIR/../travis/postgresql.sql $DIR
     docker build --tag artifact-listener-postgres $DIR 
     
     # Run an instance of Postgres with settings matching maven-artifact-notifier-core's development.properties

--- a/docker/postgres-start.sh
+++ b/docker/postgres-start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Check to see if the Postgres container already exists
+cid=$(docker ps --all --quiet --filter "name=maven_artifact_notifier_postgres")
+
+if [ -n "$cid" ]; then
+    echo "Starting existing docker container $cid"
+    docker start $cid
+else
+    # Build a docker image
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    # Copy the SQL init script into $DIR since Docker won't pull it in from outside this directory
+    cp $DIR/../travis/postgresql.sql $DIR
+    docker build --tag artifact-listener-postgres $DIR 
+    
+    # Run an instance of Postgres with settings matching maven-artifact-notifier-core's development.properties
+    echo "Running Postgres docker container, stop with 'docker-stop-postgres.sh'"
+    docker run \
+        --name maven-artifact-notifier-postgres \
+        --env POSTGRES_USER=maven_artifact_notifier \
+        --env POSTGRES_PASSWORD=maven_artifact_notifier \
+        --env POSTGRES_DB=maven_artifact_notifier \
+        --publish 5432:5432 \
+        --detach \
+        artifact-listener-postgres
+fi
+
+echo "To tail Postgres logs, run 'docker logs --follow maven-artifact-notifier-postgres'"

--- a/docker/postgres-stop.sh
+++ b/docker/postgres-stop.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker stop maven-artifact-notifier-postgres

--- a/docker/postgresql.sql
+++ b/docker/postgresql.sql
@@ -1,3 +1,5 @@
-CREATE USER maven_artifact_notifier_test WITH PASSWORD 'maven_artifact_notifier_test';
+CREATE USER maven_artifact_notifier WITH PASSWORD 'maven_artifact_notifier';
+CREATE DATABASE maven_artifact_notifier WITH OWNER maven_artifact_notifier;
 
+CREATE USER maven_artifact_notifier_test WITH PASSWORD 'maven_artifact_notifier_test';
 CREATE DATABASE maven_artifact_notifier_test WITH OWNER maven_artifact_notifier_test;

--- a/docker/postgresql.sql
+++ b/docker/postgresql.sql
@@ -1,0 +1,3 @@
+CREATE USER maven_artifact_notifier_test WITH PASSWORD 'maven_artifact_notifier_test';
+
+CREATE DATABASE maven_artifact_notifier_test WITH OWNER maven_artifact_notifier_test;

--- a/docker/tomcat-start.sh
+++ b/docker/tomcat-start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Check to see if the Postgres container already exists
+cid=$(docker ps --all --quiet --filter "name=maven_artifact_notifier_tomcat")
+
+if [ -n "$cid" ]; then
+    echo "Starting existing docker container $cid"
+    docker start $cid
+else
+    # Run an instance of Tomcat, mounting the WAR file to be deployed
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    echo "Running Tomcat in a docker container, stop with 'docker-stop-tomcat.sh'"
+    docker run \
+        --name maven-artifact-notifier-tomcat \
+        --detach \
+        --publish 8080:8080 \
+        --link maven-artifact-notifier-postgres \
+        --volume $DIR/../maven-artifact-notifier-webapp/target/maven-artifact-notifier.war:/usr/local/tomcat/webapps/maven-artifact-notifier.war \
+        tomcat
+fi
+
+echo "To tail Tomcat logs, run 'docker logs --follow maven-artifact-notifier-tomcat'"

--- a/docker/tomcat-stop.sh
+++ b/docker/tomcat-stop.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker stop maven-artifact-notifier-tomcat

--- a/maven-artifact-notifier-core/pom.xml
+++ b/maven-artifact-notifier-core/pom.xml
@@ -98,6 +98,12 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>docker</id>
+			<properties>
+				<profile.filter.file>src/main/filters/docker.properties</profile.filter.file>
+			</properties>
+		</profile>
+		<profile>
 			<id>recette</id>
 			<properties>
 				<profile.filter.file>src/main/filters/recette.properties</profile.filter.file>

--- a/maven-artifact-notifier-core/src/main/filters/docker.properties
+++ b/maven-artifact-notifier-core/src/main/filters/docker.properties
@@ -1,0 +1,73 @@
+maven.configurationType=development
+maven.spring.profiles.active=
+maven.log4j.configurationLocations=classpath:log4j.properties,classpath:log4j-\${user.name}.properties
+
+# Database
+maven.db.type=pgsql
+maven.db.jdbcUrl=jdbc:pgsql://maven-artifact-notifier-postgres:5432/maven_artifact_notifier_test?housekeeper.enabled=false
+maven.db.user=maven_artifact_notifier_test
+maven.db.password=maven_artifact_notifier_test
+maven.db.maxPoolSize=50
+
+maven.hibernate.hbm2ddl.auto=create
+maven.hibernate.ehCache.configurationLocation=ehcache/ehcache-hibernate.xml
+
+maven.test.db.type=pgsql
+maven.test.db.jdbcUrl=jdbc:pgsql://maven-artifact-notifier-postgres:5432/maven_artifact_notifier_test?housekeeper.enabled=false
+maven.test.db.user=maven_artifact_notifier_test
+maven.test.db.password=maven_artifact_notifier_test
+maven.test.db.maxPoolSize=50
+
+maven.test.hibernate.hbm2ddl.auto=create
+
+# Solr
+maven.solr.url=http://search.maven.org/solrsearch/
+maven.solr.pool.maxTotalConnections=50
+
+# Paths
+maven.data.path=/tmp/maven-artifact-notifier
+maven.shared-data.path=/tmp/maven-artifact-notifier
+maven.test.data.path=${maven.data.path}
+
+# Security
+maven.security.passwordSalt=ooM8uo4Peap3Ae8t
+
+# Authentication
+maven.authentication.callback.baseUrl=http://localhost:8080/maven-artifact-notifier/
+
+# Notification
+maven.notification.mail.from=Maven Artifact Notifier <foo@bar.com>
+maven.notification.mail.subjectPrefix=[MavenArtifactNotifier]
+maven.notification.smtp.host=localhost
+maven.notification.smtp.port=25
+maven.notification.test.emails=noreply@openwide.fr
+maven.notification.mail.recipientsFiltered=true
+
+# Public
+maven.artifact.recentReleases.limit=3
+maven.artifact.mostFollowed.limit=3
+
+# Items per portfolio page
+maven.portfolio.itemsPerPage=15
+maven.artifact.search.itemsPerPage=50
+maven.artifact.search.recommended.limit=5
+
+# Repository
+maven.repository.sync.metadata.url=http://repo1.maven.org/maven2/%s/%s/maven-metadata.xml
+maven.repository.sync.version.pom.url=http://repo1.maven.org/maven2/%1$s/%2$s/%3$s/%2$s-%3$s.pom
+
+# Scheduler
+maven.scheduler.synchronizeAllArtifactsAndNotifyUsers.cron=0 0 1 * * *
+maven.scheduler.initializeAllArtifacts.cron=0 */10 * * * *
+maven.scheduler.checkAllLinks.cron=0 0 2 * * *
+
+maven.scheduler.dummyThreadContext.serverName=localhost
+maven.scheduler.dummyThreadContext.serverPort=8080
+maven.scheduler.dummyThreadContext.scheme=http
+
+# Notifications display
+maven.notifications.limit=30
+maven.notifications.dayCount=7
+
+# Google Analytics
+maven.google.analytics.trackingId=

--- a/maven-artifact-notifier-core/src/main/filters/docker.properties
+++ b/maven-artifact-notifier-core/src/main/filters/docker.properties
@@ -4,9 +4,9 @@ maven.log4j.configurationLocations=classpath:log4j.properties,classpath:log4j-\$
 
 # Database
 maven.db.type=pgsql
-maven.db.jdbcUrl=jdbc:pgsql://maven-artifact-notifier-postgres:5432/maven_artifact_notifier_test?housekeeper.enabled=false
-maven.db.user=maven_artifact_notifier_test
-maven.db.password=maven_artifact_notifier_test
+maven.db.jdbcUrl=jdbc:pgsql://maven-artifact-notifier-postgres:5432/maven_artifact_notifier?housekeeper.enabled=false
+maven.db.user=maven_artifact_notifier
+maven.db.password=maven_artifact_notifier
 maven.db.maxPoolSize=50
 
 maven.hibernate.hbm2ddl.auto=create


### PR DESCRIPTION
These scripts and additional configuration profile allow a developer to run a PostgreSQL database and Tomcat instance in Docker containers, making it convenient to run artifact-listener locally without managing custom installations of those dependencies.
